### PR TITLE
Fix typo in BaseParser.js

### DIFF
--- a/BaseParser.js
+++ b/BaseParser.js
@@ -148,7 +148,7 @@ class Parser {
                 continue;
             } else if (code === CODE_CARRIAGE_RETURN) {
                 let nextPos = pos + 1;
-                if (nextPos < data.length && data.charChodeAt(nextPos) === CODE_NEWLINE) {
+                if (nextPos < data.length && data.charCodeAt(nextPos) === CODE_NEWLINE) {
                     if (state.eol) {
                         state.eol.call(this, '\r\n');
                     }


### PR DESCRIPTION
charCodeAt, not charChodeAt

This only affects systems that use carriage returns (Windows). I'm not sure if/how you'd like to test this as using the autotest format would mean the carriage return (what we're testing) is basically invisible.