### PR TITLE
allow whitespace in expressions not wrapped in parenthesis

### DIFF
--- a/Parser.js
+++ b/Parser.js
@@ -96,6 +96,7 @@ const BODY_STATIC_TEXT = 2;// Body of a tag is treated as text and placeholders 
 
 const EMPTY_ATTRIBUTES = [];
 const htmlTags = require('./html-tags');
+const operators = require('./operators');
 
 class Parser extends BaseParser {
     constructor(listeners, options) {
@@ -537,6 +538,10 @@ class Parser extends BaseParser {
 
         function endExpression() {
             var expression = endPart();
+            // Probably shouldn't do this, but it makes it easier to test!
+            if(expression.parentState === STATE_ATTRIBUTE_VALUE && expression.hasUnenclosedWhitespace) {
+                expression.value = '('+expression.value+')';
+            }
             expression.parentState.expression(expression);
         }
 
@@ -938,6 +943,18 @@ class Parser extends BaseParser {
                 beginCDATA();
                 parser.skip(8);
                 return true;
+            }
+
+            return false;
+        }
+
+        function checkForOperator() {
+            var remaining = parser.data.substring(parser.pos);
+            var match = operators.pattern.exec(remaining);
+
+            if(match) {
+                parser.skip(match[0].length-1);
+                return match[0];
             }
 
             return false;
@@ -1927,6 +1944,15 @@ class Parser extends BaseParser {
                     }
 
                     if (isWhitespaceCode(code)) {
+                        if(parentState === STATE_ATTRIBUTE_VALUE && !isConcise) {
+                            var operator = checkForOperator();
+                            if(operator) {
+                                currentPart.hasUnenclosedWhitespace = true;
+                                currentPart.value += operator;
+                                return;
+                            }
+                        }
+
                         currentPart.endPos = parser.pos;
                         endExpression();
                         endAttribute();
@@ -1934,6 +1960,7 @@ class Parser extends BaseParser {
                             // Make sure we transition into parsing within the open tag
                             parser.enterState(STATE_WITHIN_OPEN_TAG);
                         }
+
                         return;
                     } else if (code === CODE_EQUAL && parentState === STATE_ATTRIBUTE_NAME) {
                         currentPart.endPos = parser.pos;

--- a/operators.js
+++ b/operators.js
@@ -1,0 +1,56 @@
+var operators = exports.operators = [
+    //Multiplicative Operators
+    '*', '/', '%',
+
+    //Additive Operators
+    '+', '-',
+
+    //Bitwise Shift Operators
+    '<<', // ambiguous (close open tag): '>>', '>>>',
+
+    //Relational Operators
+    '<', '<=', // ambiguous (close open tag): '>', '>=',
+
+    // Readable Operators
+    // NOTE: These become reserved words and cannot be used as attribute names
+    'instanceof',
+    'in',
+    // 'from', -- as in <import x from './file'/>
+    // 'typeof', -- would need to look behind, not ahead
+
+    // Equality Operators
+    '==', '!=', '===', '!==',
+
+    // Binary Bitwise Operators
+    '&', '^', '|',
+
+    // Binary Logical Operators
+    '&&', '||',
+
+    // Ternary Operator
+    '?', ':',
+
+    // Member
+    '['
+];
+
+var requiresWhitespace = exports.requiresWhitespace = {
+    'instanceof':true,
+    'in':true,
+    'typeof':true
+};
+
+exports.pattern = new RegExp('^\\s*('+operators.map(o => {
+    if(requiresWhitespace[o]) {
+        return '\\s'+escapeNonAlphaNumeric(o)+'\\s';
+    }
+    if(o === '/') {
+        return '\\/(?:\\b|\\s)'; //make sure this isn't a comment
+    }
+    return escapeNonAlphaNumeric(o);
+}).join('|')+')\\s*');
+
+function escapeNonAlphaNumeric(str) {
+    return str.replace(/([^\w\d])/g, '\\$1');
+}
+

--- a/test/fixtures/autotest/attr-operators-with-whitespace/expected.html
+++ b/test/fixtures/autotest/attr-operators-with-whitespace/expected.html
@@ -1,0 +1,3 @@
+<tag isString=(data instanceof String) x=(123 + 256) name=(lastName.toUppercase() + ', ' + firstName.toLowerCase()) age-in-years=(daysOld / 365) test=(x ? 'a' : 'b')>
+    text:"test"
+</tag>

--- a/test/fixtures/autotest/attr-operators-with-whitespace/input.htmljs
+++ b/test/fixtures/autotest/attr-operators-with-whitespace/input.htmljs
@@ -1,0 +1,1 @@
+<tag isString=data instanceof String x=123 + 256 name=lastName.toUppercase() + ', ' + firstName.toLowerCase() age-in-years=daysOld / 365 test=x ? 'a' : 'b'>test</tag>


### PR DESCRIPTION
This change allows whitespace in complex expressions such as the following:

``` xml
<assign name=lastName.toUpperCase() + ', ' + firstName.toLowerCase()/>
```

While I think in many cases (especially when involving multiple attributes), the code would be easier to read if the developer were to still wrap more complex expressions in parenthesis, it shouldn't be necessary in all cases, and the above example is very clear and arguably 
more readable without the wrapping parenthesis.

Operators that begin with `>` would still need to be wrapped - in fact they already need to be wrapped even if there is no whitespace:

``` xml
<test x=(1>2)/>
```

This is accomplished by looking ahead for binary operators.  There is a side-effect of this change: anything that is listed in the `operators.js`, essentially becomes a reserved word and cannot be used as an attribute name.  For symbolic operators, an attribute cannot even start with the operator.  So, in the case of `<test a=1 +1=true/>`, the attribute name `+1` is **not** valid (in this context).

I think this is a fair trade-off and likely wouldn't affect anyone, but let's open this up for discussion as it could potentially break existing code.  **Is anyone using attributes that don't follow the rules for javascript variable names (aside from dashes in-between words)?**  If so, why and what for?

With the way things currently stand with this pull request, `<test +1=true/>` is actually still valid, if we decide to go this route, we should probably enforce the attribute name rule explicitly for all cases, rather than them sometimes working (if they're the first attribute, or follow an attribute without a value, or follow an argument).
